### PR TITLE
allow /system/bin/make_f2fs

### DIFF
--- a/public/vold.te
+++ b/public/vold.te
@@ -181,10 +181,12 @@ allow vold user_profile_data_file:dir create_dir_perms;
 # Raw writes to misc block device
 allow vold misc_block_device:blk_file w_file_perms;
 
+# Allow /system/bin/make_f2fs
+allow vold fsck_exec:file execute_no_trans;
+
 neverallow { domain -vold } vold_data_file:dir ~{ open create read getattr setattr search relabelto ioctl };
 neverallow { domain -vold -kernel } vold_data_file:notdevfile_class_set ~{ relabelto getattr };
 neverallow { domain -vold -init } vold_data_file:dir *;
 neverallow { domain -vold -init -kernel } vold_data_file:notdevfile_class_set *;
 neverallow { domain -vold -init } restorecon_prop:property_service set;
 
-neverallow vold fsck_exec:file execute_no_trans;


### PR DESCRIPTION
enable f2fs for adoptable storage
make_f2fs will be called to format sd card

Jira: https://jira01.devtools.intel.com/browse/OAM-63182
Test: None
Signed-off-by: zhiwei li <zhiwei.li@intel.com>