### PR TITLE
add permission for mediaextractor to load data from sd card(vfat)

### DIFF
--- a/public/mediaextractor.te
+++ b/public/mediaextractor.te
@@ -24,6 +24,7 @@ crash_dump_fallback(mediaextractor)
 
 # allow mediaextractor read permissions for file sources
 allow mediaextractor media_rw_data_file:file { getattr read };
+allow mediaextractor vfat:file { getattr read };
 allow mediaextractor app_data_file:file { getattr read };
 
 # Read resources from open apk files passed over Binder


### PR DESCRIPTION
add permission for mediaextractor to load data from sd card(vfat)

Jira: https://jira01.devtools.intel.com/browse/OAM-68478
Signed-off-by: Zhiwei Li zhiwei.li@intel.com